### PR TITLE
Default column size for SQLAlchemy extension

### DIFF
--- a/guardrail/ext/sqlalchemy.py
+++ b/guardrail/ext/sqlalchemy.py
@@ -137,7 +137,7 @@ class SqlalchemyPermissionSchemaFactory(models.BasePermissionSchemaFactory):
             agent=sa.orm.relationship(agent),
             target_id=_reference_column(target, nullable=False, index=True),
             target=sa.orm.relationship(target),
-            permission=sa.Column(sa.String, nullable=False, index=True),
+            permission=sa.Column(sa.String(255), nullable=False, index=True),
         )
 
 


### PR DESCRIPTION
Issue #3. Let's try to change sqla. default column size (permission) to 255.
Same size already specified in ext.pony (line 104).
